### PR TITLE
feat: asociar el valor del input con la leyenda.

### DIFF
--- a/src/components/form/LegendForm.vue
+++ b/src/components/form/LegendForm.vue
@@ -81,7 +81,9 @@ const stopDrag = () => {
 
         <v-divider  v-if="legend.focusedInput"></v-divider>
         <p v-else>On focus any input</p>
-        <h5 v-for="(score, index) in btn_info_ask[legend.focusedInput]"><span class="type_score"> {{ score }}</span><br></h5>
+        <h5 v-for="(score, index) in btn_info_ask[legend.focusedInput]">
+          <span :class="(legend.inputValue==(btn_info_ask[legend.focusedInput].length - 1 - index))? 'type_score_weight type_score':'type_score'"> {{ score }}</span><br>
+        </h5>
       </div>
     </div>
   </div>
@@ -129,6 +131,9 @@ const stopDrag = () => {
 }
 .type_score{
   font-weight: normal;
+}
+.type_score_weight{
+  font-weight: bolder;
 }
 .draggable {
   position: absolute;

--- a/src/components/form/content/ContentCluster.vue
+++ b/src/components/form/content/ContentCluster.vue
@@ -125,10 +125,14 @@ const getColumnsSizeLabel = () => {
   return (route.name !== 'Relevance' && route.name !== 'SDQF') ? (windowWidth.value < 1440 ? '' : '3') : (windowWidth.value < 1440 ? '' : '4');
 };
 
-const onFocus=(e,nameQuestion)=>{
+const onFocus=(e,nameQuestion, number)=>{
   if(e){
     legendInput.setFocusedInput(nameQuestion);
+    onChange(number)
   }
+}
+const onChange=(number)=>{
+  legendInput.setInputValue(number);
 }
 
 watch([() => route.name, () => props.active], () => {
@@ -183,7 +187,8 @@ watch(inputValues, calculateMean, { deep: true });
                 :hideInput="false" inset :min="0" :max="3"
                 v-model="inputValues[route.name][active][block.title][activity][column]"
                 :disabled="checkDisable(indexColumn, column, activity, block.title)"
-                @update:focused="(e)=>onFocus (e, column)"
+                @update:focused="(e)=>onFocus (e, column,inputValues[route.name][active][block.title][activity][column])"
+                @update:modelValue="onChange(inputValues[route.name][active][block.title][activity][column])"
               >
               </v-number-input>
               <v-number-input v-else

--- a/src/components/form/content/Results.vue
+++ b/src/components/form/content/Results.vue
@@ -11,7 +11,8 @@ const generateReport =()=>{
 const legendInput=useInputFocusLegend();
 onBeforeMount(()=>{
   tokenReport.value=true;
-  legendInput.clearFocusedInput()
+  legendInput.clearFocusedInput();
+  legendInput.clearInputValue();
 })
 const dialog=ref(false)
 

--- a/src/components/stores/legendFocusStore.js
+++ b/src/components/stores/legendFocusStore.js
@@ -3,13 +3,20 @@ import {defineStore} from "pinia";
 export const useInputFocusLegend=defineStore( 'legend',{
     state:()=>({
         focusedInput:'',
+        inputValue:null,
     }),
     actions:{
         setFocusedInput(inputName){
             this.focusedInput=inputName;
         },
         clearFocusedInput() {
-            this.focusedInput = ''; // Limpia el estado cuando no hay foco
+            this.focusedInput = '';
+        },
+        setInputValue(value){
+            this.inputValue=value;
+        },
+        clearInputValue() {
+            this.inputValue=null;
         },
     },
 });


### PR DESCRIPTION
## **Ticket**

[Mejorar leyenda del formulario](https://trello.com/c/KQTfvkp2/Mejorar-leyenda-del-formulario)

## **Problem**

La aplicación tenía una leyenda que no estaba asociado el valor del input con la leyenda.  

## **Changelog**

- Añadir resaltado en la leyenda en relación con el valor que hay en el input.

## **How to test**

1. Cuando entras en el formulario, hay un botón legend en la esquina superior izquierda.
2. Pulsa en ese botón y aparecerá una ventana emergente que se puede arrastrar de sitio.  
3. Cuando se pulsa en algún input del cuestionario, la ventana emergente cambiará de texto. Mostrando el texto en relación al input que estás.
4. Cuando cambiar de valor se resaltará en la leyenda el valor correspondiente.

## **Type of change**

- [x] New feature (non-breaking change which adds functionality)


